### PR TITLE
Update Rails dependency to equal or greater than Rails 6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     timely_scopes (0.1.0)
-      rails (~> 6.0.0)
+      rails (>= 6.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -140,4 +140,4 @@ DEPENDENCIES
   timely_scopes!
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/timely_scopes.gemspec
+++ b/timely_scopes.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 6.0.0"
+  spec.add_dependency "rails", ">= 6.0.0"
 
   spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
~> 6.0.0 means >= 6.0.0 and < 6.1 which blocks upgrades to Rails 6.1